### PR TITLE
Fix Notice, every html_head element needs a key

### DIFF
--- a/packages/uebertool-companion/src/Hook/PageHooks.php
+++ b/packages/uebertool-companion/src/Hook/PageHooks.php
@@ -14,7 +14,8 @@ class PageHooks {
       [
         '#tag' => 'style',
         '#value' => '@layer properties, theme, base, drupal, components, utilities;',
-      ]
+      ],
+      'uebertool_companion_layer',
     ];
   }
 


### PR DESCRIPTION
\Drupal\Core\Render\HtmlResponseAttachmentsProcessor::processHtmlHead