### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@ueberbit/stylelint-config",
   "version": "0.8.1",
+  "bugs": {
+    "url": "https://github.com/ueberbit/uebertool/issues"
+  },
   "description": "UEBERBIT StyleLint config",
   "author": {
     "name": "UEBERBIT GmbH",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/stylelint-config/package.json`.